### PR TITLE
fix: Changed how transactions are managed to keep hexagonal architecture

### DIFF
--- a/database/src/lib.rs
+++ b/database/src/lib.rs
@@ -4,4 +4,3 @@ pub mod schema;
 pub mod db_handle;
 
 pub use db_handle::DbHandle;
-pub use db_handle::TransactionHandler;


### PR DESCRIPTION
The way I initially setup the database was too complex to use, with dependent projects having to manage transactions on their end, which isn't unit test friendly. This refactor makes it easier to manage.